### PR TITLE
Add username argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Install the global CLI!
 ```sh
 npm install -g gitwrite-cli
 ```
-From there, run the `gitwrite` command in a new repository. Once you have a new repository, run `gitwrite <year> "<message>"`. The message must be in quotes. GitWrite will ask you for confirmation, and then make however many commits you need to add the text to your graph. If you ever want to remove it, just delete the GitHub repo.
+From there, run the `gitwrite` command in a new repository. Once you have a new repository, run `gitwrite <year> "<message>" <username>`. The message must be in quotes. The username should be your GitHub profile's username, and if not provided, GitWrite will get a username from your Git global config. GitWrite will ask you for confirmation, and then make however many commits you need to add the text to your graph. If you ever want to remove it, just delete the GitHub repo.

--- a/index.js
+++ b/index.js
@@ -13,18 +13,18 @@ process.argv.shift();
 if (isNaN(process.argv[0])) process.argv.shift();
 const args = process.argv;
 
-const [year, message] = args.map(v => isNaN(v) ? v : +v);
+const [year, message, username] = args.map(v => isNaN(v) ? v : +v);
 
 (async () => {
     if (!year || !message) return console.log('Welcome to GitWrite! GitWrite lets you add a message to your GitHub contribution graph. To begin, make a new GitHub repo, clone it locally, and get ready to add commits!\n\nRun this command again with this syntax: gitwrite <year> <message>.\nMessage should be in qotes. Messages can only have alphanumeric characters, spaces. and some symbols.');
 
-    const username = (await run('git config user.name')).trim();
-    const data = await fetch('https://api.github.com/users/' + username).then(r => r.json());
-    if (data.message) return console.log('Invalid GitHub username "' + username + '"');
+    const gitUsername = (await run('git config user.name')).trim();
+    const data = await fetch('https://api.github.com/users/' + (username ? username : gitUsername)).then(r => r.json());
+    if (data.message) return console.log('Invalid GitHub username "' + gitUsername + '"');
 
     const commands = type(year, message);
 
-    console.log(`Welcome, ${username}!`);
+    console.log(`Welcome, ${username ? username: gitUsername}!`);
     console.log(`Using git repo in directory ${process.cwd()},`);
     console.log(`Staging ${commands.length / 6} commits to write ${message} in ${year}...`);
     prompt('Press enter to continue...');


### PR DESCRIPTION
Hey! This PR introduces another argument that can be passed into GitWrite: `username`. Since the Git-configured username may not always be a user's GitHub username, you should consider allowing the user to enter their GitHub username (which overrides the Git-configured username).

Let me know what you think! 🙌 